### PR TITLE
transitively expose keybindingapi and mixinsqared at compiletime

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,11 +23,11 @@ dependencies {
 	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 
 	// MixinSquared
-	include(implementation(annotationProcessor "com.github.bawnorton.mixinsquared:mixinsquared-fabric:${project.mixinsquared}"))
+	include(api(annotationProcessor "com.github.bawnorton.mixinsquared:mixinsquared-fabric:${project.mixinsquared}"))
 
 	// Fabric API
 	//include(modImplementation "net.fabricmc.fabric-api:fabric-key-binding-api-v1:1.0.36+fb8d95da77")
-	include(modImplementation "com.github.tildejustin:key-binding-api:a41fc49671")
+	include(modApi "com.github.tildejustin:key-binding-api:a41fc49671")
 	//include(modImplementation "net.fabricmc.fabric-api:fabric-resource-loader-v0:0.2.7+c668f41583")
 }
 


### PR DESCRIPTION
this didn't use to work on jitpack(?), looks like it now does. up to you whether you want it but I think it makes more sense instead of every mod also having an implementation keybinding api as well, can always do { transitive = false } if a project doesn't want it on the compile path for some reason.